### PR TITLE
Detect pkglibexecdir properly

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,8 @@
 dist_bin_SCRIPTS = eos-google-chrome
 
 dist_pkglibexec_SCRIPTS = eos-google-chrome-installer
+
+dist_pkgdata_DATA = config.py
+
+config.py: config.py.in Makefile
+	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $<> $@

--- a/src/config.py.in
+++ b/src/config.py.in
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+#
+# eos-google-chrome-installer: helper script to install Google Chrome
+#
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Authors:
+#  Michal Rostecki <michal@kinvolk.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+pkglibexecdir = "@pkglibexecdir@"

--- a/src/eos-google-chrome
+++ b/src/eos-google-chrome
@@ -25,6 +25,8 @@ import os
 import subprocess
 import sys
 
+sys.path.append("/usr/share/eos-google-chrome-helper")
+import config
 import gi
 gi.require_version('Flatpak', '1.0')
 from gi.repository import Flatpak
@@ -71,7 +73,7 @@ class GoogleChromeLauncher:
 
     def _install_chrome(self):
         try:
-            subprocess.Popen(['/usr/libexec/eos-google-chrome-installer'])
+            subprocess.Popen(['/{}/eos-google-chrome-installer'.format(config.pkglibexecdir)])
         except OSError as e:
             exit_with_error("Could not launch Chrome: {}".format(repr(e)))
 


### PR DESCRIPTION
Before this change, we assumed that it will be /usr/libexec, which is true only for Red Hat based Linux distributions.