### PR TITLE
Don't run the installer on auto start if the stamp file exists

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -18,7 +18,10 @@ polkit_policydir = $(datadir)/polkit-1/actions
 polkit_policy_in_files = com.endlessm.GoogleChromeHelper.system-helper.policy.in
 polkit_policy_DATA = $(polkit_policy_in_files:.policy.in=.policy)
 
-do_edit = sed -e "s|\@pkgdatadir\@|$(pkgdatadir)|"
+do_edit = sed \
+	-e "s|\@localstatedir\@|$(localstatedir)|" \
+	-e "s|\@pkgdatadir\@|$(pkgdatadir)|" \
+	-e "s|\@PACKAGE\@|$(PACKAGE)|"
 
 %.policy: %.policy.in Makefile
 	$(AM_V_GEN) $(do_edit) $<> $@

--- a/data/com.endlessm.GoogleChromeInitialSetup.desktop.in
+++ b/data/com.endlessm.GoogleChromeInitialSetup.desktop.in
@@ -4,3 +4,4 @@ Exec=@pkgdatadir@/eos-google-chrome-installer.py --initial-setup
 Type=Application
 NoDisplay=true
 X-GNOME-Autostart-enabled=true
+AutostartCondition=unless-exists @localstatedir@/lib/@PACKAGE@/initial-setup-done


### PR DESCRIPTION
Now that we have support for absolute paths in gnome-session, we can
specify the system-wide level stamp file in AutostartCondition.

https://phabricator.endlessm.com/T15400