### PR TITLE
debian: Remove eos-install-app-helper install file

### DIFF
--- a/debian/eos-install-app-helper.install
+++ b/debian/eos-install-app-helper.install
@@ -1,7 +1,0 @@
-/usr/bin/eos-install-app-helper
-/usr/share/appdata
-/usr/share/applications/eos-skype.desktop
-/usr/share/applications/eos-spotify.desktop
-/usr/share/applications/eos-vlc.desktop
-/usr/share/eos-install-app-helper
-/usr/share/icons


### PR DESCRIPTION
When there's only a single binary package, there's no reason to specify
an install file since you just want all the files that get installed to
go to that package.

That's what dh_auto_install assumes and installs the files directly to
debian/$package. Unfortunately, dh_install assumes that if you have a
.install file, it should migrate files from debian/tmp to
debian/$package.

https://phabricator.endlessm.com/T16839