### PR TITLE
T18657: Call "refine" action on gnome-sofwtare on placeholder apps

### DIFF
--- a/apps/com.microsoft.Skype/eos-skype.desktop.in
+++ b/apps/com.microsoft.Skype/eos-skype.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Skype
-Exec=/usr/bin/eos-install-app-helper --app-id com.microsoft.Skype --remote eos-apps --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.microsoft.Skype --remote eos-apps --source-app-id eos-skype.desktop --required-archs x86_64 %U
 Terminal=false
 Icon=eos-skype
 Type=Application

--- a/apps/com.spotify.Client/eos-spotify.desktop.in
+++ b/apps/com.spotify.Client/eos-spotify.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Spotify
-Exec=/usr/bin/eos-install-app-helper --app-id com.spotify.Client --remote eos-apps --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.spotify.Client --remote eos-apps --source-app-id eos-spotify.desktop --required-archs x86_64 %U
 Terminal=false
 Icon=eos-spotify
 Type=Application

--- a/apps/org.videolan.VLC/eos-vlc.desktop.in
+++ b/apps/org.videolan.VLC/eos-vlc.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get VLC
-Exec=/usr/bin/eos-install-app-helper --app-id org.videolan.VLC --remote eos-apps --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id org.videolan.VLC --remote eos-apps --source-app-id eos-vlc.desktop --required-archs x86_64 %U
 Terminal=false
 Icon=eos-vlc
 Type=Application


### PR DESCRIPTION
This changeset calls the newly-added "refine" action in gnome-software which ensures that the placeholder app is refined at the time the install-window is presented to the user. The placeholder application needs to be refined so that gnome-software knows which desktop file to replace once the installation completes.

https://phabricator.endlessm.com/T18657