### PR TITLE
data: Remove libreoffice from flatpak autoinstall for now

### DIFF
--- a/data/10-autoinstall.conf
+++ b/data/10-autoinstall.conf
@@ -1,1 +1,0 @@
-flathub:org.libreoffice.Libreoffice


### PR DESCRIPTION
We dont have that remote configured and the installation will
fail, blocking system updates.

https://phabricator.endlessm.com/T16682