### PR TITLE
Spotify and Skype: fix replaced by app ID

### DIFF
--- a/apps/com.microsoft.Skype/eos-skype.desktop.in
+++ b/apps/com.microsoft.Skype/eos-skype.desktop.in
@@ -5,4 +5,4 @@ Exec=/usr/bin/eos-install-app-helper --app-id com.microsoft.Skype --remote eos-a
 Terminal=false
 Icon=eos-skype
 Type=Application
-X-Endless-Replaced-By=org.skype.Skype.desktop
+X-Endless-Replaced-By=com.microsoft.Skype.desktop

--- a/apps/com.spotify.Client/eos-spotify.desktop.in
+++ b/apps/com.spotify.Client/eos-spotify.desktop.in
@@ -5,4 +5,4 @@ Exec=/usr/bin/eos-install-app-helper --app-id com.spotify.Client --remote eos-ap
 Terminal=false
 Icon=eos-spotify
 Type=Application
-X-Endless-Replaced-By=org.spotify.Client.desktop
+X-Endless-Replaced-By=com.spotify.Client.desktop


### PR DESCRIPTION
The wrong ID was causing the "Get X" launcher to show on desktop search.

https://phabricator.endlessm.com/T19796