### PR TITLE
flatpak-installer: Add 10-default.json for flatpak autoinstall

### DIFF
--- a/data/10-default.json
+++ b/data/10-default.json
@@ -1,0 +1,10 @@
+[
+  {
+    "action": "install",
+    "serial": 2018011300,
+    "ref-kind": "app",
+    "name": "com.endlessm.CompanionAppService",
+    "collection-id": "com.endlessm.Apps",
+    "remote": "eos-apps"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,4 +6,4 @@ dist_iconoverrides_DATA = eos-icon-overrides.ini
 # already been uninstalled).
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
-dist_flatpaks_DATA = 10-autoinstall.conf
+dist_flatpaks_DATA = 10-default.json


### PR DESCRIPTION
And install com.endlessm.CompanionAppService by default

https://phabricator.endlessm.com/T20708