### PR TITLE
T20867:  flatpak-autoinstall: add EndlessOS icon theme to autoinstall list (eos3.3 branch)

### DIFF
--- a/data/50-eos3.3.json
+++ b/data/50-eos3.3.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2018012300,
+    "ref-kind": "runtime",
+    "collection-id": "com.endlessm.Sdk",
+    "remote": "eos-sdk",
+    "name": "org.freedesktop.Platform.Icontheme.EndlessOS",
+    "branch": "1.0"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,4 +6,4 @@ dist_iconoverrides_DATA = eos-icon-overrides.ini
 # already been uninstalled).
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
-dist_flatpaks_DATA = 10-autoinstall.conf
+dist_flatpaks_DATA = 50-eos3.3.json


### PR DESCRIPTION
Based on patches in master, but applying to an eos3.3 specific file to account for the serial numbers progressing differently in master and eos3.3. This means that if someone removes the icon theme manually, and then upgrades to 3.4 they'll get it back, but this seems fairly harmless for something which doesn't appear in the app center and is (at present) an identical set of files to those that ship in the OS.

https://phabricator.endlessm.com/T20867