### PR TITLE
Include a --branch option to the scripts

### DIFF
--- a/apps/com.spotify.Client/eos-spotify.desktop.in
+++ b/apps/com.spotify.Client/eos-spotify.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Spotify
-Exec=/usr/bin/eos-install-app-helper --app-id com.spotify.Client --remote flathub --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.spotify.Client --remote flathub --branch stable --required-archs x86_64 %U
 Terminal=false
 Icon=eos-spotify
 Type=Application

--- a/apps/org.videolan.VLC/eos-vlc.desktop.in
+++ b/apps/org.videolan.VLC/eos-vlc.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get VLC
-Exec=/usr/bin/eos-install-app-helper --app-id org.videolan.VLC --remote flathub --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id org.videolan.VLC --remote flathub --branch stable --required-archs x86_64 %U
 Terminal=false
 Icon=eos-vlc
 Type=Application

--- a/src/eos-install-app-helper.py
+++ b/src/eos-install-app-helper.py
@@ -45,6 +45,7 @@ class InstallAppHelperLauncher:
     def __init__(self,
                  app_id,
                  remote,
+                 branch,
                  params):
         self._params = params
         try:
@@ -52,9 +53,9 @@ class InstallAppHelperLauncher:
         except GLib.Error as e:
             exit_with_error("Could not find current system installation: {}".format(repr(e)))
 
-        self._start(app_id, remote)
+        self._start(app_id, remote, branch)
 
-    def _start(self, app_id, remote):
+    def _start(self, app_id, remote, branch):
         is_installed = self._is_flatpak_installed(app_id)
         if is_installed:
             logging.info("Flatpak for {} found. Launching...".format(app_id))
@@ -62,7 +63,8 @@ class InstallAppHelperLauncher:
         else:
             logging.info("Could not find flatpak for {}. Running installation script...".format(app_id))
             self._install_app_id(app_id,
-                                 remote)
+                                 remote,
+                                 branch)
 
     def _run_app(self, app_id, params):
         logging.info("Launching {} flatpak app through desktop file".format(app_id))
@@ -78,11 +80,15 @@ class InstallAppHelperLauncher:
 
     def _install_app_id(self,
                         app_id,
-                        remote):
+                        remote,
+                        branch):
+        extra_args = []
+        if branch:
+            extra_args.extend(['--branch', branch])
         try:
             subprocess.Popen([os.path.join(config.PKG_DATADIR, 'eos-install-app-helper-installer.py'),
                               '--app-id', app_id,
-                              '--remote', remote])
+                              '--remote', remote] + extra_args)
         except OSError as e:
             exit_with_error("Could not launch {}: {}".format(app_id, repr(e)))
 
@@ -123,6 +129,7 @@ if __name__ == '__main__':
     parser.add_argument('--debug', dest='debug', action='store_true')
     parser.add_argument('--app-id', dest='app_id', help='Flatpak App ID', type=str, required=True)
     parser.add_argument('--remote', dest='remote', help='Flatpak Remote', type=str, required=True)
+    parser.add_argument('--branch', dest='branch', help='Flatpak Branch', type=str, default='', required=False)
     parser.add_argument('--required-archs', dest='required_archs', default=[], nargs='*', type=str)
 
     parsed_args, otherargs = parser.parse_known_args()
@@ -136,5 +143,6 @@ if __name__ == '__main__':
 
     InstallAppHelperLauncher(parsed_args.app_id,
                              parsed_args.remote,
+                             parsed_args.branch,
                              otherargs)
     sys.exit(0)


### PR DESCRIPTION
The app helper installer assumes that an app's branch must be the
default one set for the remote we determine for the app. However, some
remotes do not have this default branch set, which results in the scrips
passing only the simple app IDs to GNOME Software, resulting in it
calling a search rather than showing the details page for the apps.

So this patch adds a branch option which will be used for calculating
the apps' unique ID, and thus open the apps' details page in GNOME
Software. If the branch is not passed, then it continues to look for
the remotes' default branch as before.

https://phabricator.endlessm.com/T21493