### PR TITLE
flatpak-autoinstall: migrate to EknServicesMultiplexer

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -41,5 +41,35 @@
     "remote": "eos-sdk",
     "name": "com.endlessm.CompanionAppService",
     "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2018050100,
+    "ref-kind": "app",
+    "name": "com.endlessm.EknServices",
+    "branch": "eos3"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2018050101,
+    "ref-kind": "app",
+    "name": "com.endlessm.EknServices2",
+    "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2018050102,
+    "ref-kind": "app",
+    "name": "com.endlessm.EknServices3",
+    "branch": "stable"
+  },
+  {
+    "action": "install",
+    "serial": 2018050103,
+    "ref-kind": "app",
+    "collection-id": "com.endlessm.Sdk",
+    "remote": "eos-sdk",
+    "name": "com.endlessm.EknServicesMultiplexer",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
The versioned EknServices apps have been replaced by one EknServicesMultiplexer
flatpak which contains the services for all currently supported SDKs which are
installed.

We must remove the old ones first so that the .service files are removed from
the Flatpak export path before the multiplexer is installed, as it exports the
same names.

https://phabricator.endlessm.com/T22063