### PR TITLE
flatpak-autoinstall: remove EndlessOS icon theme auto-install entry

### DIFF
--- a/data/50-eos3.3.json
+++ b/data/50-eos3.3.json
@@ -1,11 +1,2 @@
 [
-  {
-    "action": "install",
-    "serial": 2018012300,
-    "ref-kind": "runtime",
-    "collection-id": "com.endlessm.Sdk",
-    "remote": "eos-sdk",
-    "name": "org.freedesktop.Platform.Icontheme.EndlessOS",
-    "branch": "1.0"
-  }
 ]


### PR DESCRIPTION
Improve the robustness of upgrades from early 3.3 releases (where the
upgrader has gained support for Flatpak auto installs) to the latest
3.3 release. We found bugs with the automatic creation of Flatpak
remotes meaning that eos-sdk might not exist, which would prevent
the system upgrading past this point.

This auto-install entry is present in master so will be re-added when
the systems upgrade to 3.4.0, after which the users will have received
the fix ensuring that eos-sdk/flathub remotes are added successfully.

https://phabricator.endlessm.com/T22258