### PR TITLE
flatpak-autoinstall: split to separate eos-flatpak-autoinstall package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+eos-application-tools (1.0.4) eos; urgency=medium
+
+  * Split Flatpak auto-installation JSON files to architecture-independent
+    eos-flatpak-autoinstall package so they are included on ARM systems.
+
+  https://phabricator.endlessm.com/T22652
+
+ -- Robert McQueen <rob@endlessm.com>  Mon, 21 May 2018 16:53:47 +0100
+
 eos-application-tools (1.0.3) eos; urgency=medium
 
   * Remove eos-browser-helper and Google Chrome specifics from this package,

--- a/debian/control
+++ b/debian/control
@@ -20,3 +20,10 @@ Depends: ${misc:Depends},
 Description: Wrapper application for desktop launchers
  Small package to implementing desktop launchers for certain apps on Endless OS
  when installed, or redirecting the user to the App Center otherwise.
+
+Package: eos-flatpak-autoinstall
+Architecture: all
+Description: data files of automatic Flatpak operations for upgrades
+ These JSON files are used by the updater (since Endless OS 3.4.0) to enumerate
+ the Flatpak install, uninstall and update operations which should be carried
+ out automatically when the OS is upgraded.

--- a/debian/eos-flatpak-autoinstall.install
+++ b/debian/eos-flatpak-autoinstall.install
@@ -1,0 +1,1 @@
+usr/share/eos-application-tools/flatpak-autoinstall.d

--- a/debian/eos-install-app-helper.install
+++ b/debian/eos-install-app-helper.install
@@ -1,0 +1,7 @@
+usr/bin
+usr/share/appdata
+usr/share/applications
+usr/share/eos-application-tools/icon-overrides
+usr/share/eos-install-app-helper
+usr/share/icons
+usr/share/locale


### PR DESCRIPTION
Split Flatpak auto-installation JSON files to architecture-independent
eos-flatpak-autoinstall package so they are included on ARM systems.

https://phabricator.endlessm.com/T22652