### PR TITLE
defaults: remove CompanionAppService

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -71,5 +71,12 @@
     "remote": "eos-sdk",
     "name": "com.endlessm.EknServicesMultiplexer",
     "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2019032800,
+    "ref-kind": "app",
+    "name": "com.endlessm.CompanionAppService",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
The companion app itself is currently not available for download, and
we don't currently have the resources to resurrect it and investigate
issues that were reported before it was pulled from Google Play. (I have
the app installed on my tablet; while it can see my Endless computers on
the network, it fails to actually load any content from either of them.)

For the time being, remove the integration from the OS.

Tested by copying the file into place and manually running `sudo /lib/x86_64-linux-gnu/eos-updater-flatpak-installer`.

https://phabricator.endlessm.com/T25970