### PR TITLE
Specify branch in Get Dropbox/Skype/Unity launchers

### DIFF
--- a/apps/com.dropbox.Client/eos-dropbox.desktop.in
+++ b/apps/com.dropbox.Client/eos-dropbox.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Dropbox
-Exec=/usr/bin/eos-install-app-helper --app-id com.dropbox.Client --remote flathub --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.dropbox.Client --remote flathub --branch stable --required-archs x86_64 %U
 Terminal=false
 Icon=eos-dropbox
 Type=Application

--- a/apps/com.skype.Client/eos-skype.desktop.in
+++ b/apps/com.skype.Client/eos-skype.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Skype
-Exec=/usr/bin/eos-install-app-helper --app-id com.skype.Client --remote flathub --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.skype.Client --remote flathub --branch stable --required-archs x86_64 %U
 Terminal=false
 Icon=eos-skype
 Type=Application

--- a/apps/com.unity.UnityHub/eos-unity.desktop.in
+++ b/apps/com.unity.UnityHub/eos-unity.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Get Unity
-Exec=/usr/bin/eos-install-app-helper --app-id com.unity.UnityHub --remote flathub --required-archs x86_64 %U
+Exec=/usr/bin/eos-install-app-helper --app-id com.unity.UnityHub --remote flathub --branch stable --required-archs x86_64 %U
 Terminal=false
 Icon=eos-unity
 Type=Application


### PR DESCRIPTION
Without this, GNOME Software opens at a search results page rather than
at the app in question. The Spotify and VLC launchers do this correctly.

https://phabricator.endlessm.com/T26193