### PR TITLE
defaults: remove CompanionAppService.Locale

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -78,5 +78,12 @@
     "ref-kind": "app",
     "name": "com.endlessm.CompanionAppService",
     "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2019053000,
+    "ref-kind": "runtime",
+    "name": "com.endlessm.CompanionAppService.Locale",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
77ef14b207e4886a963639da69a9d6f4e1f5b485 removed the service itself but
did not remove the locale extension.

It's empty -- but it's untidy to leave it around.

https://phabricator.endlessm.com/T25970