### PR TITLE
installer: Fix app's unique ID generation

### DIFF
--- a/src/eos-install-app-helper-installer.py
+++ b/src/eos-install-app-helper-installer.py
@@ -97,9 +97,9 @@ class InstallAppHelperInstaller:
             branch = remote.get_default_branch()
 
         if branch:
-            app_app_center_id = 'system/flatpak/{}/desktop/{}.desktop/{}'.format(remote_name,
-                                                                                 app_id,
-                                                                                 branch)
+            app_app_center_id = 'system/flatpak/{}/desktop/{}/{}'.format(remote_name,
+                                                                         app_id,
+                                                                         branch)
         return app_app_center_id
 
     def _run_app_center_for_app(self, app_id, remote, branch):


### PR DESCRIPTION
Remove `.desktop` suffix which is appending to the app's
unique id. This is done because there was a mis-match
between gnome-software flatpak plugin's created GsApp with source-id
as : system/flatpak/eos-apps/desktop/<app-id>/eos3

versus

A wildcard app being created in gnome-software with unique-id from
eos-install-app-helper-installer as:
system/flatpak/eos-apps/desktop/<app-id>.desktop/eos3

The mismatch resulted in a broken app's detail page  in OS images
built with gnome-software 3.32.

The mismatch occured because of a change in gnome-software-3-32,
where the flatpak plugin strips the `.desktop` suffix from the
appstream. See gs_flatpak_fix_id_desktop_suffix_cb in gnome-software
flatpak's plugin.

Needless to say, this change should be accompained with
versions >= 3.32 for gnome-software, hence should be cherry-picked
to stable branches accordingly.

https://phabricator.endlessm.com/T27508