### PR TITLE
flatpak-autoinstall: remove endlessm.OperatingSystemApp

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -128,5 +128,12 @@
     "ref-kind": "app",
     "name": "com.endlessm.Clubhouse",
     "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2019102500,
+    "ref-kind": "app",
+    "name": "com.endlessm.OperatingSystemApp",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
We have a new version under the hack_computer namespace.

https://phabricator.endlessm.com/T28554