### PR TITLE
flatpak-autoinstall: update com.hack_computer.Clubhouse

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -154,5 +154,12 @@
     "ref-kind": "app",
     "name": "com.endlessm.Sidetrack",
     "branch": "stable"
+  },
+  {
+    "action": "update",
+    "serial": 2020040300,
+    "ref-kind": "app",
+    "name": "com.hack_computer.Clubhouse",
+    "branch": "eos3"
   }
 ]


### PR DESCRIPTION
The clubhouse should be updated in 3.8.0 to ensure that it works
with the shell changes.

https://phabricator.endlessm.com/T29619