### PR TITLE
Add "Get Zoom" desktop launcher

### DIFF
--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -29,6 +29,7 @@ desktop_in_files = \
 	com.spotify.Client/eos-spotify.desktop.in \
 	com.unity.UnityHub/eos-unity.desktop.in \
 	org.videolan.VLC/eos-vlc.desktop.in \
+	us.zoom.Zoom/eos-get-us.zoom.Zoom.desktop.in \
 	$(NULL)
 
 desktopdir = $(datadir)/applications

--- a/apps/us.zoom.Zoom/eos-get-us.zoom.Zoom.desktop.in
+++ b/apps/us.zoom.Zoom/eos-get-us.zoom.Zoom.desktop.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=Get Zoom
+Exec=/usr/bin/eos-install-app-helper --app-id us.zoom.Zoom --remote flathub --branch stable --required-archs x86_64 %U
+Terminal=false
+Icon=/var/lib/flatpak/appstream/flathub/x86_64/active/icons/128x128/us.zoom.Zoom.png
+Type=Application
+X-Endless-Replaced-By=us.zoom.Zoom.desktop

--- a/data/eos-icon-overrides.ini
+++ b/data/eos-icon-overrides.ini
@@ -1,5 +1,14 @@
 [Overrides]
 com.dropbox.Client.desktop=eos-dropbox.desktop
+com.endlessnetwork.MidnightmareTeddy.desktop=eos-get-com.endlessnetwork.MidnightmareTeddy.desktop
+com.endlessnetwork.aqueducts.desktop=eos-get-com.endlessnetwork.aqueducts.desktop
+com.endlessnetwork.dragonsapprentice.desktop=eos-get-com.endlessnetwork.dragonsapprentice.desktop
+com.endlessnetwork.frogsquash.desktop=eos-get-com.endlessnetwork.frogsquash.desktop
+com.endlessnetwork.missilemath.desktop=eos-get-com.endlessnetwork.missilemath.desktop
+com.endlessnetwork.passage.desktop=eos-get-com.endlessnetwork.passage.desktop
+com.endlessnetwork.tankwarriors.desktop=eos-get-com.endlessnetwork.tankwarriors.desktop
+com.google.AndroidStudio.desktop=eos-android-studio.desktop
 com.microsoft.Skype.desktop=eos-skype.desktop
 com.spotify.Client.desktop=eos-spotify.desktop
+com.unity.UnityHub.desktop=eos-unity.desktop
 org.videolan.VLC.desktop=eos-vlc.desktop

--- a/data/eos-icon-overrides.ini
+++ b/data/eos-icon-overrides.ini
@@ -12,3 +12,4 @@ com.microsoft.Skype.desktop=eos-skype.desktop
 com.spotify.Client.desktop=eos-spotify.desktop
 com.unity.UnityHub.desktop=eos-unity.desktop
 org.videolan.VLC.desktop=eos-vlc.desktop
+us.zoom.Zoom.desktop=eos-get-us.zoom.Zoom.desktop


### PR DESCRIPTION
Zoom is the dominant app for schools and universities forced to teach
remotely during the COVID-19 pandemic.

Unlike other launchers in this project, this does not add an appdata
file blacklisting the .desktop file. I couldn't find the Get Zoom
launcher in the app center when I tested this locally, so for whatever
unknown reason this seems no longer necessary. If wider testing confirms
this, we can drop the files for other launchers.

I also realised one can just use the absolute path to an icon, and so
rather than shipping a named 64×64 and 128×128 icon in the system path,
we can probably get away with linking directly to the cached icon from
Flathub, which is used when showing Zoom in the app center. This is a
bit imperfect because desktop icons are only 64×64 on low-dpi systems,
so the 128×128 icon (used here for the benefit of high-dpi systems) will
be downscaled. I couldn't see the difference on my low-dpi system, and
the simplification is pleasing.

https://phabricator.endlessm.com/T30089