### PR TITLE
flatpak-autoinstall: Install org.gnome.Totem on OS upgrade

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -161,5 +161,14 @@
     "ref-kind": "app",
     "name": "com.hack_computer.Clubhouse",
     "branch": "eos3"
+  },
+  {
+    "action": "install",
+    "serial": 2020090700,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Totem",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
We’re going to use the flathub version instead of the Debian package.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T25765