### PR TITLE
Remove org.freedesktop.Platform.Icontheme.EndlessOS on upgrade

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -170,5 +170,12 @@
     "remote": "flathub",
     "name": "org.gnome.Totem",
     "branch": "stable"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2020102100,
+    "ref-kind": "runtime",
+    "name": "org.freedesktop.Platform.Icontheme.EndlessOS",
+    "branch": "1.0"
   }
 ]


### PR DESCRIPTION
Icon theme Flatpaks are deprecated. Modern Flatpak makes the host's icon
themes available in /run/host/share/icons.
https://github.com/flatpak/flatpak/commit/1ee74fc5e

We already have an EndlessOS icon theme in the host. The only thing it
does not contain is application icon overrides. We have decided to stop
overriding these icons, triggered by the different components of
LibreOffice having differently-styled icons.

Remove the icon theme Flatpak on upgraded systems.

https://phabricator.endlessm.com/T30537
