### PR TITLE
Uninstall ProjectLibrary app

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -177,5 +177,15 @@
     "ref-kind": "runtime",
     "name": "org.freedesktop.Platform.Icontheme.EndlessOS",
     "branch": "1.0"
+  },
+  {
+    "action": "uninstall",
+    "serial": 2020110500,
+    "ref-kind": "app",
+    "name": "com.hack_computer.ProjectLibrary",
+    "branch": "eos3",
+    "filters": {
+        "architecture": ["x86_64"]
+    }
   }
 ]


### PR DESCRIPTION
The ProjectLibrary app is not needed anymore, the content is included in
the clubhouse now.

https://phabricator.endlessm.com/T31036