### PR TITLE
flatpak-autoinstall: update com.hack_computer.Clubhouse

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -177,5 +177,12 @@
     "ref-kind": "runtime",
     "name": "org.freedesktop.Platform.Icontheme.EndlessOS",
     "branch": "1.0"
+  },
+  {
+    "action": "update",
+    "serial": 2020110600,
+    "ref-kind": "app",
+    "name": "com.hack_computer.Clubhouse",
+    "branch": "eos3"
   }
 ]


### PR DESCRIPTION
The Clubhouse should be updated with 3.9.0 to ensure that it works
with the recent hack extension changes.

https://phabricator.endlessm.com/T30957