### PR TITLE
flatpak-autoinstall: update Kolibri app with 3.9.3

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -177,5 +177,12 @@
     "remote": "flathub",
     "name": "org.chromium.Chromium",
     "branch": "stable"
+  },
+  {
+    "action": "update",
+    "serial": 2021020500,
+    "ref-kind": "app",
+    "name": "org.learningequality.Kolibri",
+    "branch": "stable"
   }
 ]


### PR DESCRIPTION
We need to make sure to update the Kolibri app with 3.9.3
when transitioning to Kolibri system wide.

https://phabricator.endlessm.com/T31182