### PR TITLE
flatpak-autoinstall: Install org.gnome.Rhythmbox3 on OS upgrade

### DIFF
--- a/data/51-rhythmbox.json
+++ b/data/51-rhythmbox.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021022200,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Rhythmbox3",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -2,4 +2,4 @@
 # already been uninstalled).
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
-dist_flatpaks_DATA = 50-default.json
+dist_flatpaks_DATA = 50-default.json 51-rhythmbox.json


### PR DESCRIPTION
We are going to direct users to rhythmbox's flatpak from flathub.

Note that I used a new/separate file here to avoid having to hold merging in case of issues with serial... I used `51-rhythmbox.json` but wonder if we should use a different name here (or stick to one file per app that we change from now on and that is not already listed on `50-default.json`).

https://phabricator.endlessm.com/T31426