### PR TITLE
flatpak-autoinstall: Install org.gnome.Cheese on OS upgrade

### DIFF
--- a/data/52-cheese.json
+++ b/data/52-cheese.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021022500,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Cheese",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -2,4 +2,7 @@
 # already been uninstalled).
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
-dist_flatpaks_DATA = 50-default.json 51-rhythmbox.json
+dist_flatpaks_DATA = \
+	50-default.json \
+	51-rhythmbox.json \
+	52-cheese.json


### PR DESCRIPTION
We are going to direct users to cheese's flatpak from flathub.

https://phabricator.endlessm.com/T31429