### PR TITLE
Remove Quote/Word of the Day on upgrade

### DIFF
--- a/data/50-remove-evergreen.json
+++ b/data/50-remove-evergreen.json
@@ -1,0 +1,16 @@
+[
+  {
+    "action": "uninstall",
+    "branch": "eos3",
+    "serial": 2021100801,
+    "ref-kind": "app",
+    "name": "com.endlessm.word_of_the_day.en"
+  },
+  {
+    "action": "uninstall",
+    "branch": "eos3",
+    "serial": 2021100802,
+    "ref-kind": "app",
+    "name": "com.endlessm.quote_of_the_day.en"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,5 +4,6 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
 	50-default.json \
+	50-remove-evergreen.json \
 	51-rhythmbox.json \
 	52-cheese.json


### PR DESCRIPTION
These apps are not directly launchable. They were intended to power "evergreen" content in the Discovery Feed (RIP). Since there is no more Discovery Feed, we can remove them and free up a tiny bit of space.

https://phabricator.endlessm.com/T32624