### PR TITLE
flatpak-autoinstall: Install org.gnome.gedit on OS upgrade

### DIFF
--- a/data/50-gedit.json
+++ b/data/50-gedit.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021122700,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.gedit",
+    "branch": "stable"
+  }
+]

--- a/data/50-gnome-calculator.json
+++ b/data/50-gnome-calculator.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021122800,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Calculator",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -5,6 +5,7 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 dist_flatpaks_DATA = \
 	50-default.json \
 	50-gedit.json \
+	50-gnome-calculator.json \
 	50-remove-evergreen.json \
 	51-rhythmbox.json \
 	52-cheese.json \

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,6 +4,7 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
 	50-default.json \
+	50-gedit.json \
 	50-remove-evergreen.json \
 	51-rhythmbox.json \
 	52-cheese.json \


### PR DESCRIPTION
Move gedit from deb package to flatpak app.

https://phabricator.endlessm.com/T32879