### PR TITLE
flatpak-autoinstall: Install org.gnome.clocks on OS upgrade

### DIFF
--- a/data/50-gnome-clocks.json
+++ b/data/50-gnome-clocks.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021122800,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.clocks",
+    "branch": "stable"
+  }
+]


### PR DESCRIPTION
Move gnome-clocks from deb package to flatpak app.

https://phabricator.endlessm.com/T32904