### PR TITLE
flatpak-autoinstall: Install org.gnome.Logs on OS upgrade

### DIFF
--- a/data/50-gnome-logs.json
+++ b/data/50-gnome-logs.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2021123000,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Logs",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,6 +6,7 @@ dist_flatpaks_DATA = \
 	50-default.json \
 	50-gedit.json \
 	50-gnome-calculator.json \
+	50-gnome-logs.json \
 	50-remove-evergreen.json \
 	51-rhythmbox.json \
 	52-cheese.json \


### PR DESCRIPTION
Move gnome-logs from deb package to flatpak app.

https://phabricator.endlessm.com/T32908