### PR TITLE
flatpak-autoinstall: Install org.gnome.font-viewer on OS upgrade

### DIFF
--- a/data/50-font-viewer.json
+++ b/data/50-font-viewer.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2022010600,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.font-viewer",
+    "branch": "stable"
+  }
+]


### PR DESCRIPTION
Move gnome-font-viewer from deb package to flatpak app.

https://phabricator.endlessm.com/T32912