### PR TITLE
flatpak-autoinstall: Add missed font-viewer.json to Makefile

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
+	50-font-viewer.json \
 	50-gedit.json \
 	50-gnome-calculator.json \
 	50-gnome-logs.json \


### PR DESCRIPTION
Fixes: 2c11cb49f801 ("flatpak-autoinstall: Install org.gnome.font-viewer on OS upgrade")

https://phabricator.endlessm.com/T32912