### PR TITLE
flatpak-autoinstall: Install org.gnome.Contacts on OS upgrade

### DIFF
--- a/data/50-gnome-contacts.json
+++ b/data/50-gnome-contacts.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2022020800,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Contacts",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,6 +6,7 @@ dist_flatpaks_DATA = \
 	50-font-viewer.json \
 	50-gedit.json \
 	50-gnome-calculator.json \
+	50-gnome-contacts.json \
 	50-gnome-logs.json \
 	50-remove-evergreen.json \
 	51-rhythmbox.json \


### PR DESCRIPTION
Move gnome-contacts from deb package to flatpak app.

https://phabricator.endlessm.com/T32983