### PR TITLE
flatpak-autoinstall: Install org.gnome.FileRoller on OS upgrade

### DIFF
--- a/data/50-file-roller.json
+++ b/data/50-file-roller.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2022021000,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.FileRoller",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
+	50-file-roller.json \
 	50-font-viewer.json \
 	50-gedit.json \
 	50-gnome-calculator.json \


### PR DESCRIPTION
Move file-roller from deb package to flatpak app.

https://phabricator.endlessm.com/T33040