### PR TITLE
Update EknServicesMultiplexer

### DIFF
--- a/data/50-default.json
+++ b/data/50-default.json
@@ -1,0 +1,9 @@
+[
+  {
+    "action": "update",
+    "serial": 2022021800,
+    "ref-kind": "app",
+    "name": "com.endlessm.EknServicesMultiplexer",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
+	50-default.json \
 	50-file-roller.json \
 	50-font-viewer.json \
 	50-gedit.json \


### PR DESCRIPTION
It previously used a '--filesystem' argument that is incompatible with
Flatpak 1.12.

TODO before merge:

- [x] Release EknServicesMultiplexer with the fixes from https://github.com/endlessm/eos-knowledge-services-multiplexer/pull/21 / https://github.com/endlessm/eos-knowledge-services/pull/116 before 

https://phabricator.endlessm.com/T33181
