### PR TITLE
flatpak-autoinstall: Install org.gnome.eog on OS upgrade

### DIFF
--- a/data/50-eog.json
+++ b/data/50-eog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2022120600,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.eog",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,6 +4,7 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
 	50-default.json \
+	50-eog.json \
 	50-file-roller.json \
 	50-font-viewer.json \
 	50-gedit.json \


### PR DESCRIPTION
Move eog from deb package to flatpak app.

https://phabricator.endlessm.com/T31659