### PR TITLE
data: Add Epiphany autoinstall

### DIFF
--- a/data/50-epiphany.json
+++ b/data/50-epiphany.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2023022100,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Epiphany",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,6 +4,7 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
 	50-default.json \
+	50-epiphany.json \
 	50-file-roller.json \
 	50-font-viewer.json \
 	50-gedit.json \
@@ -11,4 +12,5 @@ dist_flatpaks_DATA = \
 	50-gnome-contacts.json \
 	50-gnome-logs.json \
 	52-cheese.json \
-	53-shotwell.json
+	53-shotwell.json \
+	$(NULL)


### PR DESCRIPTION
Although Chromium remains the default browser, Epiphany is required for Personal Web Application (PWA) support.

https://phabricator.endlessm.com/T34479