### PR TITLE
flatpak-autoinstall: Install org.gnome.Loupe on OS upgrade

### DIFF
--- a/data/50-loupe.json
+++ b/data/50-loupe.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2024030600,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Loupe",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -10,5 +10,6 @@ dist_flatpaks_DATA = \
 	50-gedit.json \
 	50-gnome-calculator.json \
 	50-gnome-contacts.json \
+	50-loupe.json \
 	53-shotwell.json \
 	$(NULL)


### PR DESCRIPTION
Install [GNOME Image Viewer (codename Loupe)](https://flathub.org/apps/org.gnome.Loupe) from Flathub

```
$ flatpak info org.gnome.Loupe

Image Viewer - View images

          ID: org.gnome.Loupe
         Ref: app/org.gnome.Loupe/x86_64/stable
        Arch: x86_64
      Branch: stable
     Version: 45.3
     License: GPL-3.0-or-later
      Origin: flathub
  Collection: org.flathub.Stable
Installation: system
   Installed: 27.3 MB
     Runtime: org.gnome.Platform/x86_64/45
         Sdk: org.gnome.Sdk/x86_64/45

      Commit: 9d8dcffa160fc376f9a6c6cfb5d593afd00753852e1391876c1fce2e5e71033f
      Parent: 99cfd7225f1666ba5d0f8535bffa7ec1095b45b85f38ca7e052fdca20db1428c
     Subject: Update loupe-45.2.tar.xz to 45.3 (874f9a71)
        Date: 2023-12-17 13:19:04 +0000
```

https://phabricator.endlessm.com/T34908