### PR TITLE
flatpak-autoinstall: Install Music & Decibels on OS upgrade

### DIFF
--- a/data/50-decibels.json
+++ b/data/50-decibels.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2024032501,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "com.vixalien.decibels",
+    "branch": "stable"
+  }
+]

--- a/data/50-music.json
+++ b/data/50-music.json
@@ -1,0 +1,11 @@
+[
+  {
+    "action": "install",
+    "serial": 2024032500,
+    "ref-kind": "app",
+    "collection-id": "org.flathub.Stable",
+    "remote": "flathub",
+    "name": "org.gnome.Music",
+    "branch": "stable"
+  }
+]

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -4,4 +4,5 @@ flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
 	50-loupe.json \
+	50-music.json \
 	$(NULL)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,7 @@
 flatpaksdir = $(datadir)/eos-application-tools/flatpak-autoinstall.d
 
 dist_flatpaks_DATA = \
+	50-decibels.json \
 	50-loupe.json \
 	50-music.json \
 	$(NULL)


### PR DESCRIPTION
```
$ flatpak info org.gnome.Music

The GNOME Music developers - Play and organize
your music collection

          ID: org.gnome.Music
         Ref: app/org.gnome.Music/x86_64/stable
        Arch: x86_64
      Branch: stable
     Version: 46.0
     License: GPL-2.0+ and LGPL-2.0+ and CC-BY-SA-4.0
      Origin: flathub
  Collection: org.flathub.Stable
Installation: system
   Installed: 9.3 MB
     Runtime: org.gnome.Platform/x86_64/46
         Sdk: org.gnome.Sdk/x86_64/46

      Commit: c41e46477f3bee284fc679f3bfaf9092…
      Parent: bf11d0368e179b8940bc447bec9b54ba…
     Subject: shared-modules: Update (dc32738a)
        Date: 2024-03-23 00:41:48 +000
```

```
$ flatpak info com.vixalien.decibels

Decibels - Play audio files

          ID: com.vixalien.decibels
         Ref: app/com.vixalien.decibels/x86_64/stable
        Arch: x86_64
      Branch: stable
     Version: 0.1.7
     License: GPL-3.0
      Origin: flathub
  Collection: org.flathub.Stable
Installation: system
   Installed: 141.3 kB
     Runtime: org.gnome.Platform/x86_64/45
         Sdk: org.gnome.Sdk/x86_64/45

      Commit: 62b9035ea5433c3fec6827bd247c91a6…
      Parent: 7ffa016f7e5691aa940808248540d18b…
     Subject: update to 0.1.7 (cf7f16c5)
        Date: 2023-12-08 17:21:13 +000
```

https://phabricator.endlessm.com/T32696